### PR TITLE
Fixed crash when Console class is not available

### DIFF
--- a/RgssDecrypter/Program.EntryPoint.cs
+++ b/RgssDecrypter/Program.EntryPoint.cs
@@ -135,7 +135,12 @@ namespace RgssDecrypter
                 assName.Version,
                 comName.Company);
             var len = header.Length;
-            header = "\x1B[" + ((Console.BufferWidth - len) / 2) + "G" + header;
+			try {
+				header = "\x1B[" + ((Console.BufferWidth - len) / 2) + "G" + header;
+			}
+			catch(IOException) {
+				// BufferWidth might not be available, e.g. when redirecting stdout 
+			}
             Console.WriteLine(header);
         }
 


### PR DESCRIPTION
Console.BufferWidth, which is used in the PrintHeader function might not
be available in certain situations, e.g. when redirecting stdout. In
such cases the program crashed with an IOException. As BufferWidth is
only used for header formatting, we can simply catch and forget it.